### PR TITLE
Fixed MG42 crash when pressing alt-fire.

### DIFF
--- a/ACTORS/Slot10Unique/Mp40.txt
+++ b/ACTORS/Slot10Unique/Mp40.txt
@@ -343,8 +343,8 @@
 			Stop
 		}
 	}
-	ACTOR HitlersBuzzsaw : BrutalWeapon
-	{
+ACTOR HitlersBuzzsaw : BrutalWeapon
+{
 		Game Doom
 		Weapon.SelectionOrder 1
 		Weapon.AmmoUse 1
@@ -359,28 +359,30 @@
 		Scale 0.8
 		States
 		{
-			Ready:
+		Ready:
 		Ready3:
-			HBUS A 1 A_WeaponReady
-					MP40 A 0 A_JumpIfInventory("GoFatality", 1, "Steady")
+			HBUS A 1 A_WeaponReady(WRF_NOSECONDARY)
+			MP40 A 0 A_JumpIfInventory("GoFatality", 1, "GoingToReady")
 			MP40 A 0 A_JumpIfInventory("Kicking",1,"DoKick")
 			MP40 A 0 A_JumpIfInventory("Taunting",1,"Taunt")
 			MP40 A 0 A_JumpIfInventory("Salute1", 1, "Salute")
 			MP40 A 0 A_JumpIfInventory("Salute2", 1, "Salute")
 			MP40 A 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
 			Loop
-				Deselect:
+			
+		Deselect:
 			HBUS A 1 A_Lower
 			Loop
 		Select:
 			HBUS A 1 A_Raise
 			TNT1 AAAAAAAAAAAA 0 A_Raise
 			GOto SelectAnimation
-				SelectAnimation:
+		
+		SelectAnimation:
 			MP40 A 0
 			MP40 A 0 A_GunFlash
 			HBUS AAAAA 1 A_Raise
-			Goto Ready
+			Goto Ready			
 		Fire:
 			MP40 A 0 BRIGHT A_FireBullets (2, 2, 1, 32, "ExtremeBulletPuff", FBF_NORANDOM | FBF_USEAMMO)
 			MP40 A 0 A_FireCustomMissile("ShakeYourAss", 0, 0, 0, 0)
@@ -394,7 +396,7 @@
 			PKCG A 0 A_SetPitch(0.6 + pitch)
 			MP40 A 0 A_SetAngle(random(2, -2) + angle)
 			HBUS A 1 A_SpawnItemEx("PlayerMuzzle1",30,5,30)
-					MP40 A 0 BRIGHT A_FireBullets (4, 4, 1, 32, "ExtremeBulletPuff", FBF_NORANDOM | FBF_USEAMMO)
+			MP40 A 0 BRIGHT A_FireBullets (4, 4, 1, 32, "ExtremeBulletPuff", FBF_NORANDOM | FBF_USEAMMO)
 			MP40 A 0 A_FireCustomMissile("DecorativeTracer", random(-1,1), 0, 2, -12, 0, random(-1,1))
 			MP40 A 0 A_PlaySound("MP40", 1)
 			MP40 A 0 A_FireCustomMissile("SmokeSpawner",0,0,0,5)
@@ -407,8 +409,9 @@
 			HBUS A 1 A_SpawnItemEx("PlayerMuzzle1",30,5,30)
 			TNT1 A 0 A_Refire
 			Goto Ready
+			
 		Spawn:
 			HBUS D -1
 			Stop
 		}
-	}
+}


### PR DESCRIPTION
This fixes a crash when pressing the secondary fire button when using the super secret weapon, the MG42. I also sorted its code for easier readability, and fixed a minor issue of calling a non-existent Steady state. However, if this weapon is going to be scrapped or replaced in the mod, please let me know.